### PR TITLE
Change assembly name to Zeiss.PiWeb.Formplot

### DIFF
--- a/src/Formplot/Formplot.csproj
+++ b/src/Formplot/Formplot.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <AssemblyName>PiWeb.Formplot</AssemblyName>
+    <AssemblyName>Zeiss.PiWeb.Formplot</AssemblyName>
     <RootNamespace>Zeiss.PiWeb.Formplot</RootNamespace>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.Year) Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
     <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>

--- a/src/Formplot/Properties/AssemblyInfo.cs
+++ b/src/Formplot/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@ using System.Runtime.CompilerServices;
 
 #endregion
 
-[assembly: InternalsVisibleTo( "PiWeb.Formplot.Tests" )]
+[assembly: InternalsVisibleTo( "Zeiss.PiWeb.Formplot.Tests" )]

--- a/src/Tests/Formplot.Tests.csproj
+++ b/src/Tests/Formplot.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <AssemblyName>PiWeb.Formplot.Tests</AssemblyName>
+    <AssemblyName>Zeiss.PiWeb.Formplot.Tests</AssemblyName>
     <RootNamespace>Zeiss.PiWeb.Formplot.Tests</RootNamespace>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.Year) Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
     <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
@@ -35,5 +35,5 @@
     <Content CopyToOutputDirectory="PreserveNewest" Include="TestData\prpx\*.prpx" />
     <Content CopyToOutputDirectory="PreserveNewest" Include="TestData\pltx\*.pltx" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
Necessary change for compatibility reasons in the PiWeb project.