### PR TITLE
fix: Uses main as reference for ZEISS-PiWeb/GitHub-Actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   release:
-    uses: ZEISS-PiWeb/github-actions/.github/workflows/create-release.yml@1.1.0
+    uses: ZEISS-PiWeb/github-actions/.github/workflows/create-release.yml@main
     with:
       generate_release_notes: true
     secrets: inherit

--- a/.github/workflows/create-support-release.yml
+++ b/.github/workflows/create-support-release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   release:
-    uses: ZEISS-PiWeb/github-actions/.github/workflows/create-support-release.yml@1.1.0
+    uses: ZEISS-PiWeb/github-actions/.github/workflows/create-support-release.yml@main
     with:
       generate_release_notes: true
     secrets: inherit

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   develop:
-    uses: ZEISS-PiWeb/github-actions/.github/workflows/develop.yml@1.1.0
+    uses: ZEISS-PiWeb/github-actions/.github/workflows/develop.yml@main
     with:
       do_pack: true  
     secrets: inherit

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   publish-feature-branch:
-    uses: ZEISS-PiWeb/github-actions/.github/workflows/feature-branch.yml@1.1.0
+    uses: ZEISS-PiWeb/github-actions/.github/workflows/feature-branch.yml@main
     with:
       do_pack: true  
     secrets: inherit


### PR DESCRIPTION
uses `@main` to reference reusable github actions since nested actions are not found otherwise.