### PR TITLE
fix: don't use geometry parameters in calculation that clone the axis and origin

### DIFF
--- a/src/Formplot/FileFormat/FormplotConverter.cs
+++ b/src/Formplot/FileFormat/FormplotConverter.cs
@@ -396,8 +396,8 @@ namespace Zeiss.PiWeb.Formplot.FileFormat
 				foreach( var point in segment.Points )
 				{
 					var curvePoint = new CurvePoint(
-						source.Actual.Position + ( source.Actual.Direction * point.Position * source.Actual.Length ),
-						source.Actual.Deviation,
+						new Vector( point.Position * source.Actual.Length ),
+						new Vector( 0, 1 ),
 						point.Deviation );
 
 					CopyDefaults( point, curvePoint );

--- a/src/Tests/FileFormat/FormplotConverterTest.cs
+++ b/src/Tests/FileFormat/FormplotConverterTest.cs
@@ -51,10 +51,10 @@ namespace Zeiss.PiWeb.Formplot.Tests.FileFormat
 
 			var points = curve.Points.ToArray();
 
-			Assert.That( points[ 0 ].Position, Is.EqualTo( new Vector( 3, 3, 3 ) ) );
+			Assert.That( points[ 0 ].Position, Is.EqualTo( new Vector( 0, 0, 0 ) ) );
 			Assert.That( points[ 0 ].Direction, Is.EqualTo( new Vector( 0, 1 ) ) );
 			Assert.That( points[ 0 ].Deviation, Is.EqualTo( 0.1 ) );
-			Assert.That( points[ 1 ].Position, Is.EqualTo( new Vector( 3, 3, 5 ) ) );
+			Assert.That( points[ 1 ].Position, Is.EqualTo( new Vector( 2, 0, 0 ) ) );
 			Assert.That( points[ 1 ].Direction, Is.EqualTo( new Vector( 0, 1 ) ) );
 			Assert.That( points[ 1 ].Deviation, Is.EqualTo( 0.2 ) );
 			Assert.That( points[ 1 ].Tolerance, Is.EqualTo( new Tolerance( 0, 0.3 ) ) );


### PR DESCRIPTION
[… ](fix: don't use geometry parameters in calculation that clone the axis and origin)